### PR TITLE
Add parser for LegionBoard

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Below you find the currently supported substitution schedule softwares and the c
 * ESchool ([example](http://eschool.topackt.com/?wp=d7406384445ce1fc9409bc90f95ccef5&go=vplan&content=x1)) `"eschool"`
 * DSBmobile (with either Untis Monitor-Vertretungsplan or DaVinci inside) `"dsbmobile"`
 * DSBlight (with Untis Monitor-Vertretungsplan inside) `"dsblight"`
+* [LegionBoard](https://legionboard.github.io) `"legionboard"`
 
 *WebUntis* is currently not supported. It should theoretically be possible to implement a corresponding parser, but keep in mind that polling its API too often (more than once an hour) is [prohibited](http://www.grupet.at/phpBB3/viewtopic.php?f=2&t=5643#p15568).
 

--- a/parser/src/main/java/me/vertretungsplan/objects/SubstitutionScheduleData.java
+++ b/parser/src/main/java/me/vertretungsplan/objects/SubstitutionScheduleData.java
@@ -72,6 +72,7 @@ public class SubstitutionScheduleData {
      *     <li>{@code "davinci"}</li>
      *     <li>{@code "turbovertretung"}</li>
      *     <li>{@code "csv"}</li>
+     *     <li>{@code "legionboard"}</li>
      * </ul>
      *
      * @param api the type of parser to use

--- a/parser/src/main/java/me/vertretungsplan/parser/BaseParser.java
+++ b/parser/src/main/java/me/vertretungsplan/parser/BaseParser.java
@@ -132,6 +132,9 @@ public abstract class BaseParser implements SubstitutionScheduleParser {
             case "csv":
                 parser = new CSVParser(data, cookieProvider);
                 break;
+            case "legionboard":
+                parser = new LegionBoardParser(data, cookieProvider);
+                break;
         }
         return parser;
     }

--- a/parser/src/main/java/me/vertretungsplan/parser/LegionBoardParser.java
+++ b/parser/src/main/java/me/vertretungsplan/parser/LegionBoardParser.java
@@ -1,0 +1,310 @@
+/*
+ * substitution-schedule-parser - Java library for parsing schools' substitution schedules
+ * Copyright (c) 2016 Johan v. Forstner
+ * Copyright (c) 2016 Nico Alt
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+ * If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package me.vertretungsplan.parser;
+
+import me.vertretungsplan.exception.CredentialInvalidException;
+import me.vertretungsplan.objects.credential.Credential;
+import me.vertretungsplan.objects.credential.UserPasswordCredential;
+import me.vertretungsplan.objects.Substitution;
+import me.vertretungsplan.objects.SubstitutionSchedule;
+import me.vertretungsplan.objects.SubstitutionScheduleData;
+import me.vertretungsplan.objects.SubstitutionScheduleDay;
+import org.apache.commons.codec.digest.DigestUtils;
+import org.apache.http.client.HttpResponseException;
+import org.joda.time.LocalDate;
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.jsoup.nodes.TextNode;
+import org.jsoup.select.Elements;
+
+import java.io.IOException;
+import java.security.NoSuchAlgorithmException;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+
+/**
+ * Parser for LegionBoard, an open source changes management system for schools.
+ *
+ * More information on the <a href="https://legionboard.github.io">official website</a>
+ * and on its <a href="https://gitlab.com/groups/legionboard">project page on GitLab</a>.
+ */
+public class LegionBoardParser extends BaseParser {
+
+	private JSONObject data;
+
+	/**
+	 * URL of given LegionBoard Heart instance
+	 */
+	private String api;
+
+	/**
+	 * URL of given LegionBoard Eye instance
+	 */
+	private String website;
+
+	public LegionBoardParser(SubstitutionScheduleData scheduleData, CookieProvider cookieProvider) {
+		super(scheduleData, cookieProvider);
+		data = scheduleData.getData();
+		try {
+			api = data.getString("api");
+			website = data.getString("website");
+		} catch (JSONException e) {
+			e.printStackTrace();
+		}
+	}
+
+	public SubstitutionSchedule getSubstitutionSchedule() throws IOException, JSONException, CredentialInvalidException {
+		final SubstitutionSchedule substitutionSchedule = SubstitutionSchedule.fromData(scheduleData);
+		substitutionSchedule.setClasses(getAllClasses());
+		substitutionSchedule.setTeachers(getAllTeachers());
+		substitutionSchedule.setWebsite(website);
+		final JSONArray changes = getChanges();
+		final JSONArray courses = getCourses();
+		final JSONArray teachers = getTeachers();
+
+		parseLegionBoard(substitutionSchedule, changes, courses, teachers);
+		return substitutionSchedule;
+	}
+
+	/**
+	 * Returns authentication key as shown
+	 * <a href="https://gitlab.com/legionboard/heart/blob/master/doc/README.md">in the documentation</a>.
+	 */
+	private String getAuthenticationKey(Credential credential) {
+		final UserPasswordCredential userPasswordCredential = (UserPasswordCredential) credential;
+		final String username = userPasswordCredential.getUsername();
+		final String password = userPasswordCredential.getPassword();
+		return DigestUtils.sha256Hex(username.toLowerCase() + "//" + password);
+	}
+
+	/**
+	 * Returns a JSONArray with all changes from now to in one week.
+	 * More information: <a href="https://gitlab.com/legionboard/heart/blob/master/doc/changes/list.md">List changes</a>
+	 */
+	private JSONArray getChanges() throws IOException, JSONException {
+		// Date (or alias of date) when the changes start
+		final String startBy = "now";
+		// Date (or alias of date) when the changes end
+		final String endBy = "i1w";
+
+		final String url = api + "/changes?startBy=" + startBy + "&endBy=" + endBy + "&k=" + getAuthenticationKey(getCredential());
+		return getJSONArray(url);
+	}
+
+	/**
+	 * Returns a JSONArray with all courses.
+	 * More information: <a href="https://gitlab.com/legionboard/heart/blob/master/doc/courses/list.md">List courses</a>
+	 */
+	private JSONArray getCourses() throws IOException, JSONException {
+		final String url = api + "/courses?k=" + getAuthenticationKey(getCredential());
+		return getJSONArray(url);
+	}
+
+	/**
+	 * Returns a JSONArray with all teachers.
+	 * More information: <a href="https://gitlab.com/legionboard/heart/blob/master/doc/teachers/list.md">List teachers</a>
+	 */
+	private JSONArray getTeachers() throws IOException, JSONException {
+		final String url = api + "/teachers?k=" + getAuthenticationKey(getCredential());
+		return getJSONArray(url);
+	}
+
+	private JSONArray getJSONArray(String url) throws IOException, JSONException {
+		try {
+			return new JSONArray(httpGet(url, "UTF-8"));
+		} catch (HttpResponseException httpResponseException) {
+			if (httpResponseException.getStatusCode() == 404) {
+				return null;
+			}
+			throw httpResponseException;
+		}
+	}
+
+	private void parseLegionBoard(SubstitutionSchedule substitutionSchedule, JSONArray changes, JSONArray courses, JSONArray teachers) throws IOException, JSONException {
+		if (changes == null) {
+			return;
+		}
+		// Link course IDs to their names
+		HashMap<String, String> coursesHashMap = null;
+		if (courses != null) {
+			coursesHashMap = new HashMap<>();
+			for (int i = 0; i < courses.length(); i++) {
+				JSONObject course = courses.getJSONObject(i);
+				coursesHashMap.put(course.getString("id"), course.getString("name"));
+			}
+		}
+		// Link teacher IDs to their names
+		HashMap<String, String> teachersHashMap = null;
+		if (teachers != null) {
+			teachersHashMap = new HashMap<>();
+			for (int i = 0; i < teachers.length(); i++) {
+				JSONObject teacher = teachers.getJSONObject(i);
+				teachersHashMap.put(teacher.getString("id"), teacher.getString("name"));
+			}
+		}
+		// Add changes to SubstitutionSchedule
+		LocalDate currentDate = null;
+		SubstitutionScheduleDay substitutionScheduleDay = new SubstitutionScheduleDay();
+		for (int i = 0; i < changes.length(); i++) {
+			if (currentDate == null) {
+				// Set date for the first time
+				currentDate = LocalDate.now();
+				substitutionScheduleDay = new SubstitutionScheduleDay();
+				substitutionScheduleDay.setDate(currentDate);
+			}
+			final JSONObject change = changes.getJSONObject(i);
+			final Substitution substitution = getSubstitution(change, coursesHashMap, teachersHashMap);
+			final LocalDate startingDate = new LocalDate(change.getString("startingDate"));
+			final LocalDate endingDate = new LocalDate(change.getString("endingDate"));
+			// Handle multi-day changes
+			if (!startingDate.isEqual(endingDate)) {
+				// If SubstitutionScheduleDay is not empty
+				if (substitutionScheduleDay.getSubstitutions() != null) {
+					substitutionSchedule.addDay(substitutionScheduleDay);
+				}
+				for (int k = 0; k < 7; k++) {
+					final LocalDate date = LocalDate.now().plusDays(k);
+					if ((date.isAfter(startingDate) || date.isEqual(startingDate)) &&
+						(date.isBefore(endingDate) || date.isEqual(endingDate))) {
+						substitutionScheduleDay = new SubstitutionScheduleDay();
+						substitutionScheduleDay.setDate(date);
+						substitutionScheduleDay.addSubstitution(substitution);
+						substitutionSchedule.addDay(substitutionScheduleDay);
+					}
+				}
+				continue;
+			}
+			// If starting date of change does not equal date of SubstitutionScheduleDay
+			if (!startingDate.isEqual(currentDate)) {
+				// If SubstitutionScheduleDay is not empty
+				if (substitutionScheduleDay.getSubstitutions() != null) {
+					substitutionSchedule.addDay(substitutionScheduleDay);
+				}
+				substitutionScheduleDay = new SubstitutionScheduleDay();
+				substitutionScheduleDay.setDate(startingDate);
+			}
+			substitutionScheduleDay.addSubstitution(substitution);
+		}
+		substitutionSchedule.addDay(substitutionScheduleDay);
+	}
+	
+	private Substitution getSubstitution(JSONObject change, HashMap<String, String> coursesHashMap, HashMap<String, String> teachersHashMap) throws IOException, JSONException {
+		final Substitution substitution = new Substitution();
+		// Set class
+		final String classId = change.getString("course");
+		if (!classId.equals("0") && classId != null) {
+			if (coursesHashMap == null) {
+				throw new IOException("Change references a course but courses are empty.");
+			}
+			final String singleClass = coursesHashMap.get(classId);
+			final HashSet<String> classes = new HashSet<>();
+			classes.add(singleClass);
+			substitution.setClasses(classes);
+		}
+		// Set type
+		String type = "Unknown";
+		switch (change.getString("type")) {
+			case "0":
+				type = "Entfall";
+				break;
+			case "1":
+				type = "Vertretung";
+				break;
+			case "2":
+				type = "Information";
+				break;
+		}
+		substitution.setType(type);
+		// Set color
+		substitution.setColor(colorProvider.getColor(type));
+		// Set covering teacher
+		final String coveringTeacherId = change.getString("coveringTeacher");
+		if (!coveringTeacherId.equals("0")) {
+			if (teachersHashMap == null) {
+				throw new IOException("Change references a covering teacher but teachers are empty.");
+			}
+			substitution.setTeacher(teachersHashMap.get(coveringTeacherId));
+		}
+		// Set teacher
+		final String teacherId = change.getString("teacher");
+		if (!teacherId.equals("0")) {
+			if (teachersHashMap == null) {
+				throw new IOException("Change references a teacher but teachers are empty.");
+			}
+			if (type.equals("Vertretung") || !coveringTeacherId.equals("0")) {
+				substitution.setPreviousTeacher(teachersHashMap.get(teacherId));
+			} else {
+				substitution.setTeacher(teachersHashMap.get(teacherId));
+			}
+				
+		}
+		// Set description
+		substitution.setDesc(change.getString("text"));
+		// Set lesson
+		final String startingHour = change.getString("startingHour");
+		final String endingHour = change.getString("endingHour");
+		if (!startingHour.equals("") || !endingHour.equals("")) {
+			String lesson = "";
+			if (!startingHour.equals("") && endingHour.equals("")) {
+				lesson = "Ab " + startingHour;
+			}
+			if (startingHour.equals("") && !endingHour.equals("")) {
+				lesson = "Bis " + endingHour;
+			}
+			if (!startingHour.equals("") && !endingHour.equals("")) {
+				lesson = startingHour + " - " + endingHour;
+			}
+			substitution.setLesson(lesson);
+		}
+		return substitution;
+	}
+
+	@Override
+	public List<String> getAllClasses() throws IOException, JSONException {
+		final List<String> classes = new ArrayList<>();
+		final JSONArray courses = getCourses();
+		if (courses == null) {
+			return null;
+		}
+		for (int i = 0; i < courses.length(); i++) {
+			final JSONObject course = courses.getJSONObject(i);
+			classes.add(course.getString("name"));
+		}
+		Collections.sort(classes);
+		return classes;
+	}
+
+	@Override
+	public List<String> getAllTeachers() throws IOException, JSONException {
+		final List<String> teachers = new ArrayList<>();
+		final JSONArray jsonTeachers = getTeachers();
+		if (jsonTeachers == null) {
+			return null;
+		}
+		for (int i = 0; i < jsonTeachers.length(); i++) {
+			final JSONObject teacher = jsonTeachers.getJSONObject(i);
+			teachers.add(teacher.getString("name"));
+		}
+		Collections.sort(teachers);
+		return teachers;
+	}
+}


### PR DESCRIPTION
I started working on the parser for [LegionBoard](https://legionboard.github.io/). As @johan12345 said, I made a copy of `SVPlanParser` to create [`LegionBoardParser`](https://github.com/johan12345/substitution-schedule-parser/compare/master...AltNico:addLegionBoard?expand=1#diff-a6e11366a1119512f844cd6eb7dd8245R1). Also, I scanned through [`SubstitutionScheduleData`](https://github.com/johan12345/substitution-schedule-parser/compare/master...AltNico:addLegionBoard?expand=1#diff-2d1ab1fb4ff397e4c8cee89e56961922R75) and  [`BaseParser`](https://github.com/johan12345/substitution-schedule-parser/compare/master...AltNico:addLegionBoard?expand=1#diff-8905e332d3ac9cf936a74ae870b13c2fR135) and added a case for `legionboard`.

@johan12345: Can you look through the changes to see whether I'm on the right way? I left a [`QUESTION` comment in `getSubstitutionSchedule()`](https://github.com/johan12345/substitution-schedule-parser/compare/master...AltNico:addLegionBoard?expand=1#diff-a6e11366a1119512f844cd6eb7dd8245R60) which you maybe can answer. Also, if you have any ideas related to a `TODO`, feel free to answer too :D

Related to #5.
