### PR TITLE
LegionBoard: fix bug with course being "null"

### DIFF
--- a/parser/src/main/java/me/vertretungsplan/parser/LegionBoardParser.java
+++ b/parser/src/main/java/me/vertretungsplan/parser/LegionBoardParser.java
@@ -196,7 +196,7 @@ public class LegionBoardParser extends BaseParser {
 		final Substitution substitution = new Substitution();
 		// Set class
 		final String classId = change.getString("course");
-		if (!classId.equals("0") && classId != null) {
+		if (!classId.equals("0") && !change.isNull("course")) {
 			if (coursesHashMap == null) {
 				throw new IOException("Change references a course but courses are empty.");
 			}


### PR DESCRIPTION
When upgrading LegionBoard Heart from `0.1.x` to `0.2+`, all existing changes get the course "null". Mistakenly, I thought the JSONObject would contain a "real" null, but the null is given as a string.

The following IOException is fixed with this commit:

```
java.io.IOException: Change references a course but courses are empty.
    at me.vertretungsplan.parser.LegionBoardParser.getSubstitution(LegionBoardParser.java:201)
    at me.vertretungsplan.parser.LegionBoardParser.parseLegionBoard(LegionBoardParser.java:160)
    at me.vertretungsplan.parser.LegionBoardParser.getSubstitutionSchedule(LegionBoardParser.java:69)
```
