### PR TITLE
LegionBoard: Respect archived courses/teachers

### DIFF
--- a/parser/src/main/java/me/vertretungsplan/parser/LegionBoardParser.java
+++ b/parser/src/main/java/me/vertretungsplan/parser/LegionBoardParser.java
@@ -272,7 +272,9 @@ public class LegionBoardParser extends BaseParser {
 		}
 		for (int i = 0; i < courses.length(); i++) {
 			final JSONObject course = courses.getJSONObject(i);
-			classes.add(course.getString("name"));
+			if (!course.getBoolean("archived")) {
+				classes.add(course.getString("name"));
+			}
 		}
 		Collections.sort(classes);
 		return classes;
@@ -287,7 +289,9 @@ public class LegionBoardParser extends BaseParser {
 		}
 		for (int i = 0; i < jsonTeachers.length(); i++) {
 			final JSONObject teacher = jsonTeachers.getJSONObject(i);
-			teachers.add(teacher.getString("name"));
+			if (!teacher.getBoolean("archived")) {
+				teachers.add(teacher.getString("name"));
+			}
 		}
 		Collections.sort(teachers);
 		return teachers;


### PR DESCRIPTION
Courses and teachers that have the archived field set to "true" should not be shown in the selection. This does not affect generating changes.

It is done in Eye too: https://gitlab.com/legionboard/eye/blob/master/src/js/changes/show.js#L274

See also: https://gitlab.com/legionboard/heart/blob/master/doc/teachers/update.md
